### PR TITLE
allow commas or spaces as list member separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ sf plugins install sf-package-list@x.y.z
 
 **Package List**
 
+> Multiple metadata members can be separated by commas or spaces.
+
 ```
 CustomLabel: Always_Be_Closing, Attention_Interest_Decision_Action, Leads_Are_Gold
 CustomObject: ABC, Glengarry, Mitch_And_Murray
@@ -141,7 +143,7 @@ EXAMPLES
 
 ## Use Case
 
-In my use case, we use `sfdx-git-delta` to create incremental packages via the git diff, but we also allow the developers to declare additional metadata to deploy via the GitLab merge request description/commit message. Instead of needing the developers to copy and paste an entire package.xml into the description, which may cause errors if XML formatting is off, we use this custom package list format to provide a simpler way for developers to provide metadata without needing to conform to the XML schema.
+In my use case, we use `sfdx-git-delta` to create incremental packages via the git diff, but we also allow the developers to declare additional metadata to deploy via the GitLab merge request description/commit message. Instead of needing the developers to copy and paste an entire `package.xml` into the description, which may cause errors if XML formatting is off, we use this custom package list format to provide a simpler way for developers to provide metadata without needing to conform to the XML schema.
 
 We also use this package list format to run destructive deployments from a GitLab web-based pipeline (created by using the "Run pipeline" button in the GitLab UI). The developer provides this list as the job-specific CI/CD variable and the pipeline converts this list into the `destructiveChanges.xml`.
 

--- a/src/helpers/listToPackageXml.ts
+++ b/src/helpers/listToPackageXml.ts
@@ -25,7 +25,7 @@ export async function listToPackageXml(list: string): Promise<string> {
       packageJson.Package.version = values;
     } else {
       packageJson.Package.types.push({
-        members: values.split(',').map(v => v.trim()),
+        members: values.split(/[\s,]+/).filter(Boolean),
         name: key,
       });
     }

--- a/test/commands/sfpl/list.nut.ts
+++ b/test/commands/sfpl/list.nut.ts
@@ -63,6 +63,6 @@ describe('sfpc combine NUTs', () => {
     const expectedOutput = await readFile(package3, 'utf-8');
     const actualOutput = await readFile(outputXml, 'utf-8')
     expect(output.trim()).to.equal('The package XML has been written to package.xml');
-    strictEqual(actualOutput, expectedOutput, `Mismatch between ${package2} and ${outputXml}`);
+    strictEqual(actualOutput, expectedOutput, `Mismatch between ${package3} and ${outputXml}`);
   });
 });

--- a/test/commands/sfpl/list.nut.ts
+++ b/test/commands/sfpl/list.nut.ts
@@ -11,6 +11,8 @@ describe('sfpc combine NUTs', () => {
   const list1 = resolve('test/samples/list1.txt');
   const package2 = resolve('test/samples/package2.xml');
   const list2 = resolve('test/samples/list2.txt');
+  const package3 = resolve('test/samples/package3.xml');
+  const list3 = resolve('test/samples/list3.txt');
   const outputXml = resolve('package.xml');
 
   before(async () => {
@@ -45,6 +47,20 @@ describe('sfpc combine NUTs', () => {
     const command = `sfpl xml -l ${list2}`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
     const expectedOutput = await readFile(package2, 'utf-8');
+    const actualOutput = await readFile(outputXml, 'utf-8')
+    expect(output.trim()).to.equal('The package XML has been written to package.xml');
+    strictEqual(actualOutput, expectedOutput, `Mismatch between ${package2} and ${outputXml}`);
+  });
+  it('convert the package 3 into list format.', () => {
+    const command = `sfpl list -x ${package3}`;
+    const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
+    const expectedOutput = 'CustomLabel: Always_Be_Closing, Attention_Interest_Decision_Action, Leads_Are_Gold\nCustomObject: ABC, Glengarry, Mitch_And_Murray\nCustomField: Glengarry.Weak_Leadz__c, Coffee.is_Closer__c\nEmailTemplate: unfiled$public/Second_Prize_Set_of_Steak_Knives\nStandardValueSet: Glengarry_Leads, Cadillac_Eldorado\nVersion: 59.0';
+    expect(output.trim()).to.equal(expectedOutput);
+  });
+  it('convert the list 3 back into a XML.', async () => {
+    const command = `sfpl xml -l ${list3}`;
+    const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
+    const expectedOutput = await readFile(package3, 'utf-8');
     const actualOutput = await readFile(outputXml, 'utf-8')
     expect(output.trim()).to.equal('The package XML has been written to package.xml');
     strictEqual(actualOutput, expectedOutput, `Mismatch between ${package2} and ${outputXml}`);

--- a/test/commands/sfpl/list.test.ts
+++ b/test/commands/sfpl/list.test.ts
@@ -75,7 +75,7 @@ describe('sfpc combine', () => {
       .getCalls()
       .flatMap((c) => c.args)
       .join('\n');
-    const expectedOutput = 'CustomLabel: Always_Be_Closing, Attention_Interest_Decision_Action, Leads_Are_Gold; CustomObject: ABC, Glengarry, Mitch_And_Murray; CustomField: Glengarry.Weak_Leadz__c, Coffee.is_Closer__c; EmailTemplate: unfiled$public/Second_Prize_Set_of_Steak_Knives; StandardValueSet: Glengarry_Leads, Cadillac_Eldorado; Version: 59.0';
+    const expectedOutput = 'CustomLabel: Always_Be_Closing, Attention_Interest_Decision_Action, Leads_Are_Gold\nCustomObject: ABC, Glengarry, Mitch_And_Murray\nCustomField: Glengarry.Weak_Leadz__c, Coffee.is_Closer__c\nEmailTemplate: unfiled$public/Second_Prize_Set_of_Steak_Knives\nStandardValueSet: Glengarry_Leads, Cadillac_Eldorado\nVersion: 59.0';
     expect(output.trim()).to.equal(expectedOutput);
   });
   it('convert the list 3 back into a XML.', async () => {

--- a/test/commands/sfpl/list.test.ts
+++ b/test/commands/sfpl/list.test.ts
@@ -15,6 +15,8 @@ describe('sfpc combine', () => {
   const list1 = resolve('test/samples/list1.txt');
   const package2 = resolve('test/samples/package2.xml');
   const list2 = resolve('test/samples/list2.txt');
+  const package3 = resolve('test/samples/package3.xml');
+  const list3 = resolve('test/samples/list3.txt');
   const outputXml = resolve('package.xml');
   const invalidPackage1 = resolve('test/samples/invalid1.xml');
 
@@ -66,6 +68,26 @@ describe('sfpc combine', () => {
     const actualOutput = await readFile(outputXml, 'utf-8')
     expect(output.trim()).to.equal('The package XML has been written to package.xml');
     strictEqual(actualOutput, expectedOutput, `Mismatch between ${package2} and ${outputXml}`);
+  });
+  it('convert the package 3 into list format.', async () => {
+    await SfplList.run(['-x', package3]);
+    const output = sfCommandStubs.log
+      .getCalls()
+      .flatMap((c) => c.args)
+      .join('\n');
+    const expectedOutput = 'CustomLabel: Always_Be_Closing, Attention_Interest_Decision_Action, Leads_Are_Gold; CustomObject: ABC, Glengarry, Mitch_And_Murray; CustomField: Glengarry.Weak_Leadz__c, Coffee.is_Closer__c; EmailTemplate: unfiled$public/Second_Prize_Set_of_Steak_Knives; StandardValueSet: Glengarry_Leads, Cadillac_Eldorado; Version: 59.0';
+    expect(output.trim()).to.equal(expectedOutput);
+  });
+  it('convert the list 3 back into a XML.', async () => {
+    await SfplXml.run(['-l', list3]);
+    const output = sfCommandStubs.log
+      .getCalls()
+      .flatMap((c) => c.args)
+      .join('\n');
+    const expectedOutput = await readFile(package3, 'utf-8');
+    const actualOutput = await readFile(outputXml, 'utf-8')
+    expect(output.trim()).to.equal('The package XML has been written to package.xml');
+    strictEqual(actualOutput, expectedOutput, `Mismatch between ${package3} and ${outputXml}`);
   });
   it('test the invalid packages.', async () => {
     await SfplList.run(['-x', invalidPackage1]);


### PR DESCRIPTION
Allows the package list to separate multiple metadata members by any combination of spaces or commas.