### PR TITLE
feat(core): validate metadata types against SDR registry in listToPackageXml

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ This makes it easier to communicate deployment scope than sharing raw `package.x
 
 **Invalid `package.xml`** — Errors from `@salesforce/source-deploy-retrieve` (unknown types, parse failures) surface as warnings and produce empty output. If a type is unrecognized, the SDR version bundled with this plugin may predate that metadata type; upgrading the plugin may resolve it.
 
-**Invalid list lines** — Each malformed line is skipped with a warning. Valid lines still produce output.
+**Invalid list lines** — Each malformed line is skipped with a warning. Valid lines still produce output. Metadata type names are also validated against the SDR registry; unknown types are skipped with a warning. If a type is unrecognized, the SDR version bundled with this plugin may predate that metadata type; upgrading the plugin may resolve it.
 
 The plugin never throws on bad input—it warns and continues.
 

--- a/src/core/listToPackageXml.ts
+++ b/src/core/listToPackageXml.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from 'node:fs/promises';
-import { PackageManifestObject } from '@salesforce/source-deploy-retrieve';
+import { PackageManifestObject, registry } from '@salesforce/source-deploy-retrieve';
 import XMLBuilder from 'fast-xml-builder';
 
 export async function listToPackageXml({
@@ -82,6 +82,11 @@ function parseListLines(lines: string[], noApiVersion: boolean, warnings: string
       if (!noApiVersion) {
         packageJson.Package.version = values;
       }
+      continue;
+    }
+
+    if (!registry.types[key.toLowerCase()] && !registry.childTypes[key.toLowerCase()]) {
+      warnings.push(`Unknown metadata type "${key}" is not in the SDR registry and will be skipped.`);
       continue;
     }
 

--- a/test/commands/sfpl/list.test.ts
+++ b/test/commands/sfpl/list.test.ts
@@ -126,6 +126,20 @@ describe('sfpc combine', () => {
     );
   });
 
+  it('should warn and skip unknown metadata types not in SDR registry.', async () => {
+    const tmpList = resolve('test/samples/output-unknown-type-list.txt');
+    await writeFile(tmpList, 'NotARealType: SomeMember\nApexClass: MyClass');
+    const { warnings, xmlPath: outPath } = await listToPackageXml({
+      listPath: tmpList,
+      xmlPath: outputXml,
+      noApiVersion: true,
+    });
+    expect(warnings).toContain('Unknown metadata type "NotARealType" is not in the SDR registry and will be skipped.');
+    const xml = await readFile(outPath, 'utf-8');
+    expect(xml).not.toContain('NotARealType');
+    expect(xml).toContain('ApexClass');
+  });
+
   it('should warn and use empty package.xml if list file does not exist', async () => {
     const badPath = resolve('test/samples/does_not_exist.txt');
     const { warnings, xmlPath } = await listToPackageXml({

--- a/test/commands/sfpl/list.test.ts
+++ b/test/commands/sfpl/list.test.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, unlink, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { strictEqual } from 'node:assert';
 import { describe, it, expect, vi } from 'vitest';
@@ -129,15 +129,21 @@ describe('sfpc combine', () => {
   it('should warn and skip unknown metadata types not in SDR registry.', async () => {
     const tmpList = resolve('test/samples/output-unknown-type-list.txt');
     await writeFile(tmpList, 'NotARealType: SomeMember\nApexClass: MyClass');
-    const { warnings, xmlPath: outPath } = await listToPackageXml({
-      listPath: tmpList,
-      xmlPath: outputXml,
-      noApiVersion: true,
-    });
-    expect(warnings).toContain('Unknown metadata type "NotARealType" is not in the SDR registry and will be skipped.');
-    const xml = await readFile(outPath, 'utf-8');
-    expect(xml).not.toContain('NotARealType');
-    expect(xml).toContain('ApexClass');
+    try {
+      const { warnings, xmlPath: outPath } = await listToPackageXml({
+        listPath: tmpList,
+        xmlPath: outputXml,
+        noApiVersion: true,
+      });
+      expect(warnings).toContain(
+        'Unknown metadata type "NotARealType" is not in the SDR registry and will be skipped.',
+      );
+      const xml = await readFile(outPath, 'utf-8');
+      expect(xml).not.toContain('NotARealType');
+      expect(xml).toContain('ApexClass');
+    } finally {
+      await unlink(tmpList);
+    }
   });
 
   it('should warn and use empty package.xml if list file does not exist', async () => {


### PR DESCRIPTION
## Summary

- `listToPackageXml` previously passed unknown metadata type names through to XML without validation, silently producing invalid package manifests
- Now cross-references each type against `registry.types` (top-level types) and `registry.childTypes` (e.g. `CustomField`, `CustomLabel`) from `@salesforce/source-deploy-retrieve`
- Unknown types emit a warning and are skipped; valid types pass through unchanged

## Test plan

- [ ] Existing 18 tests pass without modification
- [ ] New test `should warn and skip unknown metadata types not in SDR registry` verifies warning is emitted and unknown type is absent from output XML while valid type is present
- [ ] 100% statement/branch/function/line coverage maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)