### PR TITLE
feat(manifest)!: parse package.xml in-house instead of via source-deploy-retrieve

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,13 +12,8 @@ updates:
     cooldown:
       default-days: 1
     groups:
-      salesforce-source-deploy-retrieve:
-        patterns:
-          - "@salesforce/source-deploy-retrieve"
       dependencies:
         dependency-type: "production"
-        exclude-patterns:
-          - "@salesforce/source-deploy-retrieve"
       dev-dependencies:
         dependency-type: "development"
   - package-ecosystem: "github-actions"

--- a/README.md
+++ b/README.md
@@ -291,9 +291,11 @@ This makes it easier to communicate deployment scope than sharing raw `package.x
 
 ## Troubleshooting
 
-**Invalid `package.xml`** — Errors from `@salesforce/source-deploy-retrieve` (unknown types, parse failures) surface as warnings and produce empty output. If a type is unrecognized, the SDR version bundled with this plugin may predate that metadata type; upgrading the plugin may resolve it.
+Manifests and list files are parsed in-house and checked only against *structure*, not against Salesforce's metadata registry. `<name>`/type-name values are taken as-is; a misspelled or nonexistent metadata type will pass through to the output instead of being rejected here—deployment will fail on it later, not here.
 
-**Invalid list lines** — Each malformed line is skipped with a warning. Valid lines still produce output. Metadata type names are also validated against the SDR registry; unknown types are skipped with a warning. If a type is unrecognized, the SDR version bundled with this plugin may predate that metadata type; upgrading the plugin may resolve it.
+**Invalid `package.xml`** — A `<Package>` document that doesn't match the expected Metadata API manifest structure (missing/duplicate `<version>`, malformed `<types>`, unexpected elements, etc.) or has no `<types>` surfaces as a warning and produces empty output. The underlying parse error is appended to the warning.
+
+**Invalid list lines** — Each malformed line is skipped with a warning. Valid lines still produce output.
 
 The plugin never throws on bad input—it warns and continues.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,11 @@
         "@oclif/core": "4.13.5",
         "@salesforce/core": "9.1.2",
         "@salesforce/sf-plugins-core": "13.0.0",
-        "@salesforce/source-deploy-retrieve": "13.1.1",
-        "fast-xml-builder": "1.3.1"
+        "fast-xml-builder": "1.3.1",
+        "txml": "6.0.1"
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.8",
+        "@biomejs/biome": "2.5.9",
         "@commitlint/cli": "21.2.2",
         "@commitlint/config-conventional": "21.2.2",
         "@salesforce/cli-plugins-testkit": "5.3.66",
@@ -1517,9 +1517,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.8.tgz",
-      "integrity": "sha512-aeAeeJB9fSDc7Gq+2GqpQxA0qBj6gj1k2R6L1cYqGePKP/baIq1WX8y6B+D+nRsO5ViQL22K/8IwbqERW0q1nw==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.9.tgz",
+      "integrity": "sha512-KkgCvdHB4IhtpHpF564plA9jo6fDOwWGQ/3jvreLzgOtRLEDoPqr7QO9qejNA8jKwDsSkAKr77hqBHnyUbIw4g==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -1533,20 +1533,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.5.8",
-        "@biomejs/cli-darwin-x64": "2.5.8",
-        "@biomejs/cli-linux-arm64": "2.5.8",
-        "@biomejs/cli-linux-arm64-musl": "2.5.8",
-        "@biomejs/cli-linux-x64": "2.5.8",
-        "@biomejs/cli-linux-x64-musl": "2.5.8",
-        "@biomejs/cli-win32-arm64": "2.5.8",
-        "@biomejs/cli-win32-x64": "2.5.8"
+        "@biomejs/cli-darwin-arm64": "2.5.9",
+        "@biomejs/cli-darwin-x64": "2.5.9",
+        "@biomejs/cli-linux-arm64": "2.5.9",
+        "@biomejs/cli-linux-arm64-musl": "2.5.9",
+        "@biomejs/cli-linux-x64": "2.5.9",
+        "@biomejs/cli-linux-x64-musl": "2.5.9",
+        "@biomejs/cli-win32-arm64": "2.5.9",
+        "@biomejs/cli-win32-x64": "2.5.9"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.8.tgz",
-      "integrity": "sha512-mk1QON9PHllvvLN5gU3f4rMxeh4syK5p9OvKyWH6/W8ueh04uaC8TUXXByhGufWf/y5mQc03ZLM45zU+cmqMjA==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.9.tgz",
+      "integrity": "sha512-am22pX2aBqznqq1eMyIj/bZ++riF3Lk6ct7cbv+gQK0csFhr+d8O0RkOi2FF2qSgFgANbqNkIZ0/PxlnW2pLFg==",
       "cpu": [
         "arm64"
       ],
@@ -1561,9 +1561,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.8.tgz",
-      "integrity": "sha512-bsGwFMBNyHPyiLSsQcZJxdoRrg1V4JL+d7wEsvUBczlP9U9lwM+7mzQHxI4o1mhBsTmdOBbAb6fHU3Z3snN45w==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.9.tgz",
+      "integrity": "sha512-l44KWDHLDvEnD0N/XcrVs7VXb3A18xL7QS3WB0eL93wbmk529ffIG55vleGCqaunpRUjLrdnjK05Qki1dsjylg==",
       "cpu": [
         "x64"
       ],
@@ -1578,9 +1578,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.8.tgz",
-      "integrity": "sha512-XmFiA0WPYFC+uiUDC8WRFzAIH9bo7vwQLav38Uoq4ETC+T/+uBi0TsYGJECkugY3r8USl3jc+Ae2/irAF6F2lQ==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.9.tgz",
+      "integrity": "sha512-ICaK+IYaVZvKbBxX2rwrPT0DdUDMnE9Vm3nQGe+mltQPmUg19pONzkPWGdY4FCsoreDETWDynvdt4ysCbF5gNQ==",
       "cpu": [
         "arm64"
       ],
@@ -1598,9 +1598,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.8.tgz",
-      "integrity": "sha512-VcJNbstduTHx83NGAdhp78/JOcP45BZHXL7yNsfI1uGzdUgegAz2s+mSoT7wK6PBNzLoqG0zDOXaz/RQYVtSiw==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.9.tgz",
+      "integrity": "sha512-7ImVPwBLCtkmpR5esd8RHhTqW94f0JLJQum6AneYcy94jRm18TaPPm7slaigGzFhfgt3QiD1Vj52LKmBAnKizA==",
       "cpu": [
         "arm64"
       ],
@@ -1618,9 +1618,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.8.tgz",
-      "integrity": "sha512-S5wcm9OBDvLHodD4PUaN488hCpco9QD/9ZxuYJiw4euWtr/oQvLR72z2ixItH8Wd5BCm6FZaeb+YNvOoM1xHtQ==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.9.tgz",
+      "integrity": "sha512-z22Q/zFYSvbIJfW1CbfZPu4X8PddS6Qd2ORbc6h+aT6EcwAxUF3m6fA4HjNvA3TU4X0dTJRwNPB165ES3PJXzg==",
       "cpu": [
         "x64"
       ],
@@ -1638,9 +1638,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.8.tgz",
-      "integrity": "sha512-kKmiyokeISRGq2FLwvr+TzsgBusfxaZ0FZNLcOYOpCK/78tRrEjeEBLvq3xLZMpqbANgJdRPI7vZX8ZL37u9/w==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.9.tgz",
+      "integrity": "sha512-RXGaD0o1/pTTguYw1aeDJh9ad6Lfrui0fI7mBderTyGr7WuUJkBIttgLkR3XJyoxOkkgfBDspaUT8wXArTqLZw==",
       "cpu": [
         "x64"
       ],
@@ -1658,9 +1658,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.8.tgz",
-      "integrity": "sha512-nILH0mzm3Hi3iEdd7o7GpB8kBR/mSQwfQG/tyBqyNrY2GFtcgwfV9nV8xLmbtUpMNY/Oi0Ml1XgfR4flOdq+AA==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.9.tgz",
+      "integrity": "sha512-nHK+/HHC+D0ogAHUxomgoSTdjImb6fmNNVTKmf0tyu4eDL1DqPKIHc+i+UL8+b0RnAu8224qo8F2tCVnaT0A3w==",
       "cpu": [
         "arm64"
       ],
@@ -1675,9 +1675,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.8.tgz",
-      "integrity": "sha512-I2czzXTY61f3nFJxXoMDq80t7MivxDEnCjE+8sDKoFfcKMaoQdkqhIFQ3KyY0XLzeSpUBYeNAXgD+iOV/BU0VA==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.9.tgz",
+      "integrity": "sha512-Yiq0H56LjXSSw/hd9YkXgSLQfzyDJzbzU2TezozxyNw+uKWAqOtqGVvBfzKRRDiaFF5avGAhHdWKx7LtDOShUw==",
       "cpu": [
         "x64"
       ],
@@ -3674,18 +3674,6 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
-    "node_modules/@nodable/entities": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
-      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5494,79 +5482,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@salesforce/source-deploy-retrieve": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-13.1.1.tgz",
-      "integrity": "sha512-MjA3sJrjUBIK948x+frmc+/s/Pzc/sakvilBsxXbg5ITXexcmDi25nWM1h90RXdLwS3ejT7GIZCwxlzrnDzugw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@salesforce/core": "^9.0.0",
-        "@salesforce/kit": "^4.0.0",
-        "@salesforce/ts-types": "^3.0.0",
-        "@salesforce/types": "^1.6.0",
-        "fast-levenshtein": "^3.0.0",
-        "fast-xml-parser": "^5.7.3",
-        "got": "^11.8.6",
-        "graceful-fs": "^4.2.11",
-        "ignore": "^5.3.2",
-        "jszip": "^3.10.1",
-        "mime": "2.6.0",
-        "minimatch": "^9.0.9",
-        "proxy-agent": "^6.5.0",
-        "yaml": "^2.9.0"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/@salesforce/kit": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/kit/-/kit-4.0.0.tgz",
-      "integrity": "sha512-VwxhSH/8PQ5YmPAdhmLaJGCgR0n/pOm8T2y+/odMFthd5SA0xsO/kTdaRLFnFQAxxNj1nYtNHRb+BoMuAatzew==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@salesforce/ts-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/@salesforce/ts-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-3.0.1.tgz",
-      "integrity": "sha512-NWkveMYT2I3O7EAYwWHi6/ba2YUwp9MFi/zJzA+czK5MVqJfdD6FZbiQrTbALZNvFzgFSdq9BvHm6ygRmtROzw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@salesforce/ts-types": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.12.tgz",
@@ -5574,14 +5489,6 @@
       "dev": true,
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/types": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/types/-/types-1.7.1.tgz",
-      "integrity": "sha512-PyV3ZyZum8bjO1LByNXWCSOGt1b9X9x2knIiFWgnYTsHmLK8OP+f6i+wPh4qu1e8+Zr+hNV0rTKVP8p/kCGqyQ==",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@sec-ant/readable-stream": {
@@ -6358,22 +6265,6 @@
         "vitest": ">=2.0.0"
       }
     },
-    "node_modules/@szmarczak/http-timer": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
-      "dependencies": {
-        "defer-to-connect": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@tootallnate/quickjs-emscripten": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
-    },
     "node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
@@ -6407,17 +6298,6 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@types/cacheable-request": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
-      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
-      "dependencies": {
-        "@types/http-cache-semantics": "*",
-        "@types/keyv": "^3.1.4",
-        "@types/node": "*",
-        "@types/responselike": "^1.0.0"
       }
     },
     "node_modules/@types/chai": {
@@ -6454,7 +6334,8 @@
     "node_modules/@types/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q=="
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true
     },
     "node_modules/@types/jsesc": {
       "version": "2.5.1",
@@ -6462,14 +6343,6 @@
       "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/keyv": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
-      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/mute-stream": {
       "version": "0.0.4",
@@ -6484,6 +6357,7 @@
       "version": "26.2.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
       "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -6493,6 +6367,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
@@ -6509,14 +6384,6 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@types/responselike": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
-      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/shelljs": {
@@ -7054,6 +6921,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -7247,17 +7115,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/ast-types": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/ast-v8-to-istanbul": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
@@ -7397,15 +7254,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/basic-ftp": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
-      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/bin-links": {
@@ -7550,45 +7398,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/cacheable-lookup": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-      "engines": {
-        "node": ">=10.6.0"
-      }
-    },
-    "node_modules/cacheable-request": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
-      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
-      "dependencies": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^4.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^6.0.1",
-        "responselike": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/call-bind": {
@@ -8018,17 +7827,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/clone-response": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
-      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-      "dependencies": {
-        "mimic-response": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cmd-shim": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
@@ -8286,14 +8084,6 @@
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.7.0.tgz",
       "integrity": "sha512-UdtziYp5HuTz7e5j8Nvq+a/3HQo+2/aJZ9xntNTpmRRIg/3YYqDVgiS9fvAhtNbnyfbv2ZBe0bqCHqzhE7FqWQ=="
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -8376,6 +8166,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -8390,6 +8181,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -8401,6 +8193,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -8439,19 +8232,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/degenerator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-      "dependencies": {
-        "ast-types": "^0.13.4",
-        "escodegen": "^2.1.0",
-        "esprima": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/delayed-stream": {
@@ -8848,46 +8628,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -8895,14 +8635,6 @@
       "dev": true,
       "dependencies": {
         "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/event-target-shim": {
@@ -9134,28 +8866,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
-      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.2.0",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.3.0",
-        "xml-naming": "^0.1.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fastest-levenshtein": {
@@ -9588,19 +9298,6 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/get-uri": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
-      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
-      "dependencies": {
-        "basic-ftp": "^5.0.2",
-        "data-uri-to-buffer": "^6.0.2",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/github-slugger": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
@@ -9692,30 +9389,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/got": {
-      "version": "11.8.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
-      "dependencies": {
-        "@sindresorhus/is": "^4.0.0",
-        "@szmarczak/http-timer": "^4.0.5",
-        "@types/cacheable-request": "^6.0.1",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.2",
-        "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.2",
-        "lowercase-keys": "^2.0.0",
-        "p-cancelable": "^2.0.0",
-        "responselike": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
     "node_modules/graceful-fs": {
@@ -9846,7 +9519,8 @@
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true
     },
     "node_modules/http-call": {
       "version": "5.3.0",
@@ -9889,6 +9563,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -9897,22 +9572,11 @@
         "node": ">= 14"
       }
     },
-    "node_modules/http2-wrapper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
-      "dependencies": {
-        "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
-      }
-    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -9990,14 +9654,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "engines": {
-        "node": ">= 4"
-      }
     },
     "node_modules/ignore-walk": {
       "version": "8.0.0",
@@ -10321,6 +9977,7 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -11034,7 +10691,8 @@
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
     },
     "node_modules/json-file-plus": {
       "version": "4.0.1",
@@ -11218,6 +10876,7 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -11698,14 +11357,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/lowercase-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "11.5.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
@@ -11868,17 +11519,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -11904,14 +11544,6 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -12187,14 +11819,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/netmask": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
-      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -12340,17 +11964,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-url": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm-bundled": {
@@ -12935,14 +12548,6 @@
         "@oxc-resolver/binding-win32-x64-msvc": "11.24.2"
       }
     },
-    "node_modules/p-cancelable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -12963,36 +12568,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pac-proxy-agent": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
-      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
-      "dependencies": {
-        "@tootallnate/quickjs-emscripten": "^0.23.0",
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "get-uri": "^6.0.1",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.6",
-        "pac-resolver": "^7.0.1",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-resolver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-      "dependencies": {
-        "degenerator": "^5.0.0",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/pacote": {
@@ -13563,37 +13138,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/proxy-agent": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
-      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.1.0",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -13648,6 +13192,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -13845,7 +13390,8 @@
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
@@ -13865,17 +13411,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
-    "node_modules/responselike": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
-      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
-      "dependencies": {
-        "lowercase-keys": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/restore-cursor": {
@@ -14629,6 +14164,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -14660,6 +14196,7 @@
       "version": "2.8.7",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -14673,6 +14210,7 @@
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -14688,15 +14226,6 @@
       "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
@@ -14958,18 +14487,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "8.1.1",
@@ -15342,6 +14859,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/txml": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/txml/-/txml-6.0.1.tgz",
+      "integrity": "sha512-NdzaukxAFKttLElFcQevCFSGCvSyXViyX8s5zm1JP5XV/B/pX7GatMpRb+z4s9e8fKT/q2qIK8BrnBAoO2rhBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/type-detect": {
@@ -16091,21 +15617,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/xml2js": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
@@ -16145,6 +15656,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
     "@oclif/core": "4.13.5",
     "@salesforce/core": "9.1.2",
     "@salesforce/sf-plugins-core": "13.0.0",
-    "@salesforce/source-deploy-retrieve": "13.1.1",
-    "fast-xml-builder": "1.3.1"
+    "fast-xml-builder": "1.3.1",
+    "txml": "6.0.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.5.8",
+    "@biomejs/biome": "2.5.9",
     "@commitlint/cli": "21.2.2",
     "@commitlint/config-conventional": "21.2.2",
     "@salesforce/cli-plugins-testkit": "5.3.66",
@@ -251,5 +251,8 @@
   },
   "bugs": {
     "url": "https://github.com/mcarvin8/sf-package-list/issues"
+  },
+  "allowScripts": {
+    "esbuild@0.28.1": true
   }
 }

--- a/src/core/listToPackageXml.ts
+++ b/src/core/listToPackageXml.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile } from 'node:fs/promises';
-import { PackageManifestObject, RegistryAccess } from '@salesforce/source-deploy-retrieve';
 import XMLBuilder from 'fast-xml-builder';
+
+import { PackageManifestObject } from './types.js';
 
 export async function listToPackageXml({
   listPath,
@@ -40,8 +41,6 @@ export async function listToPackageXml({
 function buildXmlString(packageJson: PackageManifestObject): string {
   const builder = new XMLBuilder({ format: true, ignoreAttributes: false, indentBy: '    ' });
   let xml = builder.build(packageJson);
-  // Stryker disable next-line Regex
-  xml = xml.replace(/\s*<version>0\.0<\/version>\s*/g, '');
   xml = xml.replace(/(\s*)<\/Package>/, '\n</Package>');
   return '<?xml version="1.0" encoding="UTF-8"?>\n' + xml;
 }
@@ -51,20 +50,18 @@ function generateEmptyPackageXml(): string {
     Package: {
       '@_xmlns': 'http://soap.sforce.com/2006/04/metadata',
       types: [],
-      version: '0.0',
+      version: undefined,
     },
   };
   return buildXmlString(emptyPackage);
 }
-
-const registryAccess = new RegistryAccess();
 
 function parseListLines(lines: string[], noApiVersion: boolean, warnings: string[]): PackageManifestObject {
   const packageJson: PackageManifestObject = {
     Package: {
       '@_xmlns': 'http://soap.sforce.com/2006/04/metadata',
       types: [],
-      version: '0.0',
+      version: undefined,
     },
   };
 
@@ -84,13 +81,6 @@ function parseListLines(lines: string[], noApiVersion: boolean, warnings: string
       if (!noApiVersion) {
         packageJson.Package.version = values;
       }
-      continue;
-    }
-
-    try {
-      registryAccess.getTypeByName(key);
-    } catch {
-      warnings.push(`Unknown metadata type "${key}" is not in the SDR registry and will be skipped.`);
       continue;
     }
 

--- a/src/core/packageXmlToList.ts
+++ b/src/core/packageXmlToList.ts
@@ -1,5 +1,6 @@
-import { writeFile } from 'node:fs/promises';
-import { ComponentSet } from '@salesforce/source-deploy-retrieve';
+import { readFile, writeFile } from 'node:fs/promises';
+
+import { ParsedManifest, parseManifestXml } from './parseManifest.js';
 
 export async function packageXmlToList({
   xmlPath,
@@ -19,16 +20,16 @@ export async function packageXmlToList({
   }
 
   try {
-    const componentSet = await ComponentSet.fromManifest({ manifestPath: xmlPath });
-    const metadataTypes = groupComponentsByType(componentSet);
+    const xml = await readFile(xmlPath, 'utf-8');
+    const manifest = parseManifestXml(xml);
 
-    if (metadataTypes.size === 0) {
+    if (manifest.types.length === 0) {
       warnings.push('The provided package is invalid or has no components. Creating empty list file.');
       await writeFile(listPath, '');
       return { packageList: '', warnings };
     }
 
-    const packageList = buildPackageList(metadataTypes, componentSet.sourceApiVersion, noApiVersion);
+    const packageList = buildPackageList(manifest, noApiVersion);
     await writeFile(listPath, packageList);
     return { packageList, warnings };
   } catch (err) {
@@ -39,28 +40,12 @@ export async function packageXmlToList({
   }
 }
 
-function buildPackageList(
-  metadataTypes: Map<string, string[]>,
-  apiVersion: string | undefined,
-  noApiVersion: boolean,
-): string {
-  const lines = Array.from(metadataTypes.entries()).map(([type, members]) => `${type}: ${members.join(', ')}`);
+function buildPackageList(manifest: ParsedManifest, noApiVersion: boolean): string {
+  const lines = manifest.types.map((type) => `${type.name}: ${type.members.join(', ')}`);
 
-  if (apiVersion && !noApiVersion) {
-    lines.push(`Version: ${apiVersion}`);
+  if (manifest.version && !noApiVersion) {
+    lines.push(`Version: ${manifest.version}`);
   }
 
   return lines.join('\n');
-}
-
-function groupComponentsByType(components: ComponentSet): Map<string, string[]> {
-  const map = new Map<string, string[]>();
-  for (const component of components) {
-    const typeName = component.type.name;
-    if (!map.has(typeName)) {
-      map.set(typeName, []);
-    }
-    map.get(typeName)!.push(component.fullName);
-  }
-  return map;
 }

--- a/src/core/parseManifest.ts
+++ b/src/core/parseManifest.ts
@@ -1,0 +1,91 @@
+import { parse, TNode } from 'txml';
+
+export type ParsedManifestType = {
+  name: string;
+  members: string[];
+};
+
+export type ParsedManifest = {
+  types: ParsedManifestType[];
+  version: string | null;
+};
+
+function isElement(node: TNode | string): node is TNode {
+  return typeof node !== 'string';
+}
+
+function getText(node: TNode): string {
+  return node.children
+    .filter((child): child is string => typeof child === 'string')
+    .join('')
+    .trim();
+}
+
+function parseTypesElement(typesEl: TNode): ParsedManifestType {
+  const children = typesEl.children.filter(isElement);
+  const nameEls = children.filter((el) => el.tagName === 'name');
+  const memberEls = children.filter((el) => el.tagName === 'members');
+  const otherEl = children.find((el) => el.tagName !== 'name' && el.tagName !== 'members');
+
+  if (otherEl) {
+    throw new Error(`unexpected element <${otherEl.tagName}> inside <types>`);
+  }
+  if (nameEls.length !== 1) {
+    throw new Error(`<types> must contain exactly one <name> element, found ${nameEls.length}`);
+  }
+
+  const name = getText(nameEls[0]);
+  if (!name) {
+    throw new Error('<types><name> element must not be empty');
+  }
+  if (memberEls.length === 0) {
+    throw new Error(`<types> for "${name}" must contain at least one <members> element`);
+  }
+
+  const members = memberEls.map((memberEl) => {
+    const member = getText(memberEl);
+    if (!member) {
+      throw new Error(`<types> for "${name}" contains an empty <members> element`);
+    }
+    return member;
+  });
+
+  return { name, members };
+}
+
+/**
+ * Parses a package.xml manifest's raw text into its types/members/version.
+ * Validates only that the document follows the Metadata API manifest structure
+ * (a single <Package> root containing <types>/<version> elements) -- metadata
+ * type names are not checked against the Salesforce metadata registry.
+ */
+export function parseManifestXml(xml: string): ParsedManifest {
+  const roots = parse(xml, { decodeEntities: true, skipXmlDeclaration: true }).filter(isElement);
+
+  if (roots.length !== 1 || roots[0].tagName !== 'Package') {
+    throw new Error('manifest must have a single <Package> root element');
+  }
+
+  const types: ParsedManifestType[] = [];
+  let version: string | null = null;
+  let versionSeen = false;
+
+  for (const child of roots[0].children.filter(isElement)) {
+    if (child.tagName === 'types') {
+      types.push(parseTypesElement(child));
+    } else if (child.tagName === 'version') {
+      if (versionSeen) {
+        throw new Error('<Package> must not contain more than one <version> element');
+      }
+      versionSeen = true;
+      version = getText(child);
+      if (!version) {
+        throw new Error('<Package><version> element must not be empty');
+      }
+    } else {
+      throw new Error(`unexpected element <${child.tagName}> inside <Package>`);
+    }
+  }
+
+  return { types, version };
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -5,3 +5,11 @@ export type SfPackageListResult = {
 export type SfPackageXmlResult = {
   path: string;
 };
+
+export type PackageManifestObject = {
+  Package: {
+    '@_xmlns': string;
+    types: Array<{ name: string; members: string[] }>;
+    version: string | undefined;
+  };
+};

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -2,6 +2,7 @@
   "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "packageManager": "npm",
   "testRunner": "vitest",
+  "inPlace": true,
   "vitest": {
     "configFile": "vitest.config.ts",
     "related": false

--- a/test/commands/sfpl/list.test.ts
+++ b/test/commands/sfpl/list.test.ts
@@ -3,11 +3,15 @@ import { randomUUID } from 'node:crypto';
 import { readFile, unlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { ComponentSet } from '@salesforce/source-deploy-retrieve';
 import { describe, expect, it, vi } from 'vitest';
 
 import { listToPackageXml } from '../../../src/core/listToPackageXml.js';
 import { packageXmlToList } from '../../../src/core/packageXmlToList.js';
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return { ...actual, readFile: vi.fn(actual.readFile) };
+});
 
 describe('sfpc combine', () => {
   const package1 = resolve('test/samples/package-basic.xml');
@@ -96,16 +100,22 @@ describe('sfpc combine', () => {
     strictEqual(actualOutput, expectedOutput, `Mismatch between ${package3} and ${outputXml}`);
   });
 
-  it('confirm the invalid package provides a warning.', async () => {
-    const { warnings } = await packageXmlToList({
-      xmlPath: invalidPackage,
-      listPath: 'package.txt',
-      noApiVersion: false,
-    });
-    expect(warnings.some((w) => w.startsWith('The provided package is invalid or could not be read.'))).toBe(true);
+  it('no longer validates metadata type names in package.xml against the SDR registry (breaking change).', async () => {
+    const typoTypePath = join(tmpdir(), 'sf-package-list-test-typo-type.txt');
+    try {
+      const { packageList, warnings } = await packageXmlToList({
+        xmlPath: invalidPackage,
+        listPath: typoTypePath,
+        noApiVersion: false,
+      });
+      expect(warnings).toEqual([]);
+      expect(packageList.trim()).toEqual('CustomObjecst: ABC');
+    } finally {
+      await unlink(typoTypePath).catch(() => {});
+    }
   });
 
-  it('confirm the invalid package type provides a warning.', async () => {
+  it('confirm a structurally invalid package.xml provides a warning.', async () => {
     const invalidTypePath = join(tmpdir(), 'sf-package-list-test-invalid-type.txt');
     try {
       const { packageList, warnings } = await packageXmlToList({
@@ -113,11 +123,7 @@ describe('sfpc combine', () => {
         listPath: invalidTypePath,
         noApiVersion: false,
       });
-      expect(
-        warnings.some((w) =>
-          w.startsWith('The provided package is invalid or has no components. Creating empty list file.'),
-        ),
-      ).toBe(true);
+      expect(warnings.some((w) => w.startsWith('The provided package is invalid or could not be read.'))).toBe(true);
       expect(packageList).toBe('');
       const fileContent = await readFile(invalidTypePath, 'utf-8');
       expect(fileContent).toBe('');
@@ -132,7 +138,7 @@ describe('sfpc combine', () => {
     );
   });
 
-  it('should warn and skip unknown metadata types not in SDR registry.', async () => {
+  it('no longer validates metadata type names in list format against the SDR registry (breaking change).', async () => {
     const tmpList = resolve('test/samples/output-unknown-type-list.txt');
     await writeFile(tmpList, 'NotARealType: SomeMember\nApexClass: MyClass');
     try {
@@ -141,11 +147,9 @@ describe('sfpc combine', () => {
         xmlPath: outputXml,
         noApiVersion: true,
       });
-      expect(warnings).toContain(
-        'Unknown metadata type "NotARealType" is not in the SDR registry and will be skipped.',
-      );
+      expect(warnings).toEqual([]);
       const xml = await readFile(outPath, 'utf-8');
-      expect(xml).not.toContain('NotARealType');
+      expect(xml).toContain('<name>NotARealType</name>');
       expect(xml).toContain('ApexClass');
     } finally {
       await unlink(tmpList);
@@ -256,7 +260,7 @@ CustomObject: ABC
   it('should handle non-Error thrown values when reading package.xml', async () => {
     const xmlPath = resolve('test/samples/package-basic.xml');
     const listPath = join(tmpdir(), 'sf-package-list-test-non-error-throw.txt');
-    const spy = vi.spyOn(ComponentSet, 'fromManifest').mockRejectedValueOnce('boom-string');
+    vi.mocked(readFile).mockRejectedValueOnce('boom-string');
 
     try {
       const { packageList, warnings } = await packageXmlToList({
@@ -269,7 +273,6 @@ CustomObject: ABC
       const fileContent = await readFile(listPath, 'utf-8');
       expect(fileContent).toBe('');
     } finally {
-      spy.mockRestore();
       await unlink(listPath).catch(() => {});
     }
   });

--- a/test/core/parseManifest.test.ts
+++ b/test/core/parseManifest.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseManifestXml } from '../../src/core/parseManifest.js';
+
+const xmlns = 'http://soap.sforce.com/2006/04/metadata';
+
+describe('parseManifestXml', () => {
+  it('parses types, members, and version', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="${xmlns}">
+  <types>
+    <members>MyApexClass</members>
+    <name>ApexClass</name>
+  </types>
+  <version>60.0</version>
+</Package>`;
+
+    expect(parseManifestXml(xml)).toEqual({
+      types: [{ name: 'ApexClass', members: ['MyApexClass'] }],
+      version: '60.0',
+    });
+  });
+
+  it('parses multiple members within a single types block', () => {
+    const xml = `<Package xmlns="${xmlns}">
+  <types>
+    <members>A</members>
+    <members>B</members>
+    <name>ApexClass</name>
+  </types>
+</Package>`;
+
+    expect(parseManifestXml(xml)).toEqual({
+      types: [{ name: 'ApexClass', members: ['A', 'B'] }],
+      version: null,
+    });
+  });
+
+  it('parses multiple types blocks', () => {
+    const xml = `<Package xmlns="${xmlns}">
+  <types>
+    <members>A</members>
+    <name>ApexClass</name>
+  </types>
+  <types>
+    <members>B</members>
+    <name>ApexTrigger</name>
+  </types>
+</Package>`;
+
+    expect(parseManifestXml(xml).types).toEqual([
+      { name: 'ApexClass', members: ['A'] },
+      { name: 'ApexTrigger', members: ['B'] },
+    ]);
+  });
+
+  it('returns a null version and no types for an empty <Package>', () => {
+    const xml = `<Package xmlns="${xmlns}"></Package>`;
+    expect(parseManifestXml(xml)).toEqual({ types: [], version: null });
+  });
+
+  it('does not validate metadata type names against the Salesforce registry', () => {
+    const xml = `<Package xmlns="${xmlns}">
+  <types>
+    <members>Account.Rating__c</members>
+    <name>NotARealMetadataType</name>
+  </types>
+</Package>`;
+
+    expect(parseManifestXml(xml)).toEqual({
+      types: [{ name: 'NotARealMetadataType', members: ['Account.Rating__c'] }],
+      version: null,
+    });
+  });
+
+  it('treats type names as case-sensitive literals (no registry casing normalization)', () => {
+    const xml = `<Package xmlns="${xmlns}">
+  <types>
+    <members>A</members>
+    <name>apexclass</name>
+  </types>
+  <types>
+    <members>B</members>
+    <name>ApexClass</name>
+  </types>
+</Package>`;
+
+    expect(parseManifestXml(xml).types).toEqual([
+      { name: 'apexclass', members: ['A'] },
+      { name: 'ApexClass', members: ['B'] },
+    ]);
+  });
+
+  it('decodes XML entities in member names', () => {
+    const xml = `<Package xmlns="${xmlns}">
+  <types>
+    <members>A &amp; B</members>
+    <name>ApexClass</name>
+  </types>
+</Package>`;
+
+    expect(parseManifestXml(xml).types).toEqual([{ name: 'ApexClass', members: ['A & B'] }]);
+  });
+
+  it('throws when the root element is not <Package>', () => {
+    const xml = `<NotAPackage></NotAPackage>`;
+    expect(() => parseManifestXml(xml)).toThrow(/single <Package> root element/);
+  });
+
+  it('throws when there is more than one root element', () => {
+    const xml = `<Package></Package><Package></Package>`;
+    expect(() => parseManifestXml(xml)).toThrow(/single <Package> root element/);
+  });
+
+  it('throws on an unexpected element directly inside <Package>', () => {
+    const xml = `<Package>
+  <type>
+    <members>A</members>
+    <name>ApexClass</name>
+  </type>
+</Package>`;
+    expect(() => parseManifestXml(xml)).toThrow(/unexpected element <type> inside <Package>/);
+  });
+
+  it('throws when <Package> contains more than one <version>', () => {
+    const xml = `<Package><version>57.0</version><version>59.0</version></Package>`;
+    expect(() => parseManifestXml(xml)).toThrow(/more than one <version>/);
+  });
+
+  it('throws when <version> is empty', () => {
+    const xml = `<Package><version></version></Package>`;
+    expect(() => parseManifestXml(xml)).toThrow(/<version> element must not be empty/);
+  });
+
+  it('throws when <types> has no <name>', () => {
+    const xml = `<Package><types><members>A</members></types></Package>`;
+    expect(() => parseManifestXml(xml)).toThrow(/exactly one <name> element, found 0/);
+  });
+
+  it('throws when <types> has more than one <name>', () => {
+    const xml = `<Package><types><members>A</members><name>ApexClass</name><name>ApexTrigger</name></types></Package>`;
+    expect(() => parseManifestXml(xml)).toThrow(/exactly one <name> element, found 2/);
+  });
+
+  it('throws when <types><name> is empty', () => {
+    const xml = `<Package><types><members>A</members><name></name></types></Package>`;
+    expect(() => parseManifestXml(xml)).toThrow(/<name> element must not be empty/);
+  });
+
+  it('throws when <types> has no <members>', () => {
+    const xml = `<Package><types><name>ApexClass</name></types></Package>`;
+    expect(() => parseManifestXml(xml)).toThrow(/must contain at least one <members> element/);
+  });
+
+  it('throws when a <members> element is empty', () => {
+    const xml = `<Package><types><members>A</members><members></members><name>ApexClass</name></types></Package>`;
+    expect(() => parseManifestXml(xml)).toThrow(/contains an empty <members> element/);
+  });
+
+  it('throws on an unexpected element inside <types>', () => {
+    const xml = `<Package><types><members>A</members><name>ApexClass</name><extra>x</extra></types></Package>`;
+    expect(() => parseManifestXml(xml)).toThrow(/unexpected element <extra> inside <types>/);
+  });
+
+  it('ignores comments and whitespace-only text', () => {
+    const xml = `<Package xmlns="${xmlns}">
+  <!-- a comment -->
+  <types>
+    <members>A</members>
+    <name>ApexClass</name>
+  </types>
+</Package>`;
+    expect(parseManifestXml(xml).types).toEqual([{ name: 'ApexClass', members: ['A'] }]);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace `@salesforce/source-deploy-retrieve`'s `ComponentSet.fromManifest` and `RegistryAccess` with an in-house XML parser built on the zero-dependency `txml` package, used for both `package.xml` → list and list → `package.xml` conversion.
- Bump `@biomejs/biome` to 2.5.9 to fix a lint segfault on Windows.

## Breaking change
Metadata type names are no longer validated or case-normalized against Salesforce's metadata registry in either direction. Manifests/list files are now checked only for structural correctness (a single `<Package>` root with well-formed `<types>`/`<members>`/`<version>` elements). A misspelled or nonexistent metadata type will pass through to the output instead of being rejected here — deployment will fail on it later, not here.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `biome check` passes
- [x] `knip` passes
- [x] `vitest run --coverage` — 38/38 tests pass, coverage above thresholds
- [x] Manual diff of generated `package.xml` fixtures confirms byte-for-byte output unchanged for valid manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)